### PR TITLE
Adding basic Markdown helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const customHelpersWhitelist = [
   'endsWith',
   'eq',
   'iter',
+  'markdown',
   'possessive',
   'startsWith',
   'urlify'

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,0 +1,7 @@
+var Converter = require('showdown').converter;
+
+var converter = new Converter();
+
+module.exports = function markdown(options) {
+  return converter.makeHtml(options.fn(this));
+};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "homepage": "https://github.com/alexsomeoddpilot/lohand",
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^3.6.0",
+    "showdown": "^0.4.0"
   },
   "devDependencies": {
     "mocha": "^2.2.1",

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -1,0 +1,12 @@
+const markdown = require('../index').helpers.markdown;
+const assert = require('assert');
+
+describe('markdown', function () {
+  it('should markdown text', function () {
+    assert.equal(markdown({
+      fn: function () {
+        return '#foo';
+      }
+    }), '<h1 id="foo">foo</h1>');
+  });
+});


### PR DESCRIPTION
Converts block contents using a basic call to `showdown.makeHtml`.
