### PR TITLE
`every` iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const customHelpersWhitelist = [
   'encodeURIComponent',
   'endsWith',
   'eq',
+  'every',
   'iter',
   'possessive',
   'startsWith',

--- a/lib/every.js
+++ b/lib/every.js
@@ -5,10 +5,12 @@ module.exports = function every(amount, collection, options) {
     0 :
     options.hash.offset;
 
-  return _.reduce(collection, function (memo, item, index) {
+  function reduceCollection(memo, item, index) {
     if ((index - offset) % amount) {
       return memo + options.inverse(collection);
     }
     return memo + options.fn(collection);
-  }, '');
+  }
+
+  return _.reduce(collection, reduceCollection, '');
 };

--- a/lib/every.js
+++ b/lib/every.js
@@ -1,0 +1,14 @@
+var _ = require('lodash');
+
+module.exports = function every(amount, collection, options) {
+  var offset = options.hash.offset === undefined ?
+    0 :
+    options.hash.offset;
+
+  return _.reduce(collection, function (memo, item, index) {
+    if ((index - offset) % amount) {
+      return memo + options.inverse(collection);
+    }
+    return memo + options.fn(collection);
+  }, '');
+};

--- a/test/every.js
+++ b/test/every.js
@@ -1,0 +1,53 @@
+const every = require('../index').helpers.every;
+const assert = require('assert');
+const Spy = require('sinon').spy;
+
+describe('every', function () {
+  it('should call fn every n', function () {
+    var fnSpy = new Spy(function () {
+      return 'true';
+    });
+    var inverseSpy = new Spy(function () {
+      return 'false';
+    });
+
+    var result = every(3, [
+      'Foo',
+      'Bar',
+      'Baz'
+    ], {
+      fn: fnSpy,
+      inverse: inverseSpy,
+      hash: {}
+    });
+
+    assert.equal(fnSpy.calledOnce, true, 'only call normal once');
+    assert.equal(inverseSpy.calledTwice, true, 'call inverse two times');
+    assert.equal(result, 'truefalsefalse');
+  });
+
+  it('should respect offset', function () {
+    var fnSpy = new Spy(function () {
+      return 'true';
+    });
+    var inverseSpy = new Spy(function () {
+      return 'false';
+    });
+
+    var result = every(3, [
+      'Foo',
+      'Bar',
+      'Baz'
+    ], {
+      fn: fnSpy,
+      inverse: inverseSpy,
+      hash: {
+        offset: 1
+      }
+    });
+
+    assert.equal(fnSpy.calledOnce, true, 'only call normal once');
+    assert.equal(inverseSpy.calledTwice, true, 'call inverse two times');
+    assert.equal(result, 'falsetruefalse');
+  });
+});


### PR DESCRIPTION
Loops over collection and executes main block when `index % amount === 0`, otherwise the else case.

``` handlebars
{#every 3 ['foo', 'bar', 'baz']}
  {{this}}
{else}
  false
{/every}
// foofalsefalse
```

The helper optionally supports an `offset` parameter which modifies the index by the offset.

``` handlebars
{#every 3 ['foo', 'bar', 'baz'] offset="1"}
  {{this}}
{else}
  false
{/every}
// falsebarfalse
```
